### PR TITLE
Use bits/stdc++.h for includes

### DIFF
--- a/39F-PacifistFrogs.cpp
+++ b/39F-PacifistFrogs.cpp
@@ -1,6 +1,5 @@
-#include <cstdio>
-#include <vector>
-#include <map>
+#include <bits/stdc++.h>
+
 using namespace std;
 
 int main() {


### PR DESCRIPTION
Replaced standard includes with bits/stdc++.h for convenience.